### PR TITLE
refactor: Remove dependency on getSchemaUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@sindresorhus/slugify": "^1.1.0",
     "ajv": "^6.12.3",
     "deepdash-es": "^5.3.5",
     "typescript": "^4.1.3"

--- a/src/VcSchema.ts
+++ b/src/VcSchema.ts
@@ -2,16 +2,22 @@
 
 import Ajv from "ajv";
 import { omitDeep, mapValuesDeep } from "deepdash-es/standalone";
-import slugify from "@sindresorhus/slugify";
-import { getSchemaUrl } from "./utils";
 
 const ajv = new Ajv();
 
-export interface LdContextPlus<MetadataType = any> {
+export interface DefaultSchemaMetadata {
+  uris?: {
+    jsonLdContextPlus?: string;
+    jsonLdContext?: string;
+    jsonSchema?: string;
+  };
+}
+
+export interface LdContextPlus<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> {
   "@context": LdContextPlusRootNode<MetadataType>;
 }
 
-export interface LdContextPlusRootNode<MetadataType = any> {
+export interface LdContextPlusRootNode<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> {
   "@rootType": string;
   "@id"?: string;
   "@title"?: string;
@@ -20,7 +26,7 @@ export interface LdContextPlusRootNode<MetadataType = any> {
   [key: string]: LdContextPlusNode<MetadataType> | MetadataType | number | string | undefined;
 }
 
-export interface LdContextPlusInnerNode<MetadataType = any> {
+export interface LdContextPlusInnerNode<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> {
   "@id": string;
   "@contains"?: string;
   "@replaceWith"?: string;
@@ -31,7 +37,7 @@ export interface LdContextPlusInnerNode<MetadataType = any> {
   "@context"?: { [key: string]: LdContextPlusNode<MetadataType> };
 }
 
-export interface LdContextPlusLeafNode<MetadataType = any> {
+export interface LdContextPlusLeafNode<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> {
   "@id": string;
   "@type": string;
   "@dataType"?: string;
@@ -45,7 +51,7 @@ export interface LdContextPlusLeafNode<MetadataType = any> {
 
 export type LdContextPlusNodeKey = keyof LdContextPlusLeafNode | keyof LdContextPlusInnerNode;
 
-export type LdContextPlusNode<MetadataType = any> =
+export type LdContextPlusNode<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> =
   | LdContextPlusInnerNode<MetadataType>
   | LdContextPlusLeafNode<MetadataType>;
 
@@ -128,7 +134,6 @@ const baseVcJsonSchema = {
 };
 
 export class VcSchema {
-  public id?: string;
   public jsonSchemaMessage?: string; // @TODO/tobek This should probably be an array and some of the compilation warnings should get added to it.
   public schema: LdContextPlus;
   public jsonLdContext?: any;
@@ -137,8 +142,7 @@ export class VcSchema {
   private debugMode?: boolean;
   private jsonSchemaValidate?: Ajv.ValidateFunction;
 
-  constructor(schema: string | LdContextPlus, id?: string, debugMode?: boolean) {
-    this.id = id && slugify(id);
+  constructor(schema: string | LdContextPlus, debugMode?: boolean) {
     this.debugMode = debugMode;
     if (typeof schema === "string") {
       try {
@@ -152,26 +156,10 @@ export class VcSchema {
 
     // @TODO/tobek Should make a JSON Schema for LdContextPlus and validate `this.schema` here and throw an error if invalid.
 
-    this.jsonLdContext = omitDeep(this.schema, contextPlusFieldsRegexes);
-    if (this.jsonLdContext["@context"] && !this.jsonLdContext["@context"]["@version"]) {
-      // Default to JSON-LD proceessing mode version 1.1
-      this.jsonLdContext["@context"]["@version"] = 1.1;
-    }
-
-    // This is a bit of a hack. We want to be able to add JSON Schema info to "@id" properties. To do this we can have LD Context Plus nodes such as `{ "id" : { "@id": "@id", "@required": true } }` which compiles to JSON-LD @context `{ "id" : { "@id": "@id" } }`. This works and simply aliases "id" to "@id". However, the W3C Credentials JSON-LD @context thatn we import defines `{ @protected: true, "id": "@id" }`. Because of the "@protected" we can't redefine "id" even to an expanded type definition that is functionally identical. So, this mapValuesDeep call replaces `{ "id" : { "@id": "@id" } }` with `{ "id" : "@id" }` which is allowed by "@protected" since it is functionally *and* syntactically the same.
-    this.jsonLdContext = mapValuesDeep(
-      this.jsonLdContext,
-      (value) => {
-        if (value?.["@id"] === "@id") {
-          return "@id";
-        }
-        return value;
-      },
-      { callbackAfterIterate: true },
-    );
-
-    if (this.id && this.jsonLdContext["@context"]?.["schema-id"]) {
-      this.jsonLdContext["@context"]["schema-id"] = getSchemaUrl(this.id, "ld-context") + "#";
+    try {
+      this.jsonLdContext = this.generateJsonLdContext();
+    } catch (err) {
+      throw Error("Failed to generate JSON-LD Context from input: " + err.message);
     }
 
     try {
@@ -265,6 +253,28 @@ export class VcSchema {
     this.debugMode && console.log(...args);
   }
 
+  private generateJsonLdContext(): any {
+    let context = omitDeep(this.schema, contextPlusFieldsRegexes);
+    if (context["@context"] && !context["@context"]["@version"]) {
+      // Default to JSON-LD proceessing mode version 1.1
+      context["@context"]["@version"] = 1.1;
+    }
+
+    // This is a bit of a hack. We want to be able to add JSON Schema info to "@id" properties. To do this we can have LD Context Plus nodes such as `{ "id" : { "@id": "@id", "@required": true } }` which compiles to JSON-LD @context `{ "id" : { "@id": "@id" } }`. This works and simply aliases "id" to "@id". However, the W3C Credentials JSON-LD @context that we import defines `{ @protected: true, "id": "@id" }`. Because of the "@protected" we can't redefine "id" even to an expanded type definition that is functionally identical. So, this mapValuesDeep call replaces `{ "id" : { "@id": "@id" } }` with `{ "id" : "@id" }` which is allowed by "@protected" since it is functionally *and* syntactically the same.
+    context = mapValuesDeep(
+      context,
+      (value) => {
+        if (value?.["@id"] === "@id") {
+          return "@id";
+        }
+        return value;
+      },
+      { callbackAfterIterate: true },
+    );
+
+    return context;
+  }
+
   private generateJsonSchema(): JsonSchema | undefined {
     let context = this.schema["@context"] || this.schema;
     if (Array.isArray(context)) {
@@ -288,7 +298,7 @@ export class VcSchema {
 
     return {
       $schema: "http://json-schema.org/draft-07/schema#",
-      $id: this.id && getSchemaUrl(this.id, "json-schema"),
+      $id: this.schema["@context"]?.["@metadata"]?.uris?.jsonSchema,
       title: context["@title"],
       description: context["@description"],
       ...baseVcJsonSchema,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,0 @@
-// @TODO/tobek This config value needs to be abstracted out and passed in when creating schema instances, and then this file can be deleted.
-export interface ConfigType {
-  SCHEMA_HOST_URL: string;
-}
-const config: ConfigType = {
-  SCHEMA_HOST_URL: "https://alpha.consensysidentity.com",
-};
-
-export { config };

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -1,5 +1,3 @@
-import { getSchemaUrl } from "./utils";
-
 export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
   DiplomaCredential: `{
   "@context": {
@@ -7,6 +5,10 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
     "@rootType": "DiplomaCredential",
     "@title": "Diploma Credential",
     "@metadata": {
+      "uris": {
+        "jsonLdContext": "https://example.com/schemas/diploma-credential/ld-context.json",
+        "jsonSchema": "https://example.com/schemas/diploma-credential/json-schema.json"
+      },
       "version": "1.0",
       "slug": "diploma-credential",
       "icon": "🎓",
@@ -14,7 +16,7 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
     },
     "w3ccred": "https://www.w3.org/2018/credentials#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "schema-id": "${getSchemaUrl("diploma-credential", "ld-context-plus")}#",
+    "schema-id": "https://example.com/schemas/diploma-credential/ld-context.json#",
     "DiplomaCredential": {
       "@id": "schema-id",
       "@contains": "credentialSubject"
@@ -67,13 +69,17 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
     "@rootType": "ContentPublishCredential",
     "@title": "Content Publish Credential",
     "@metadata": {
+      "uris": {
+        "jsonLdContext": "https://example.com/schemas/content-publish-credential/ld-context.json",
+        "jsonSchema": "https://example.com/schemas/content-publish-credential/json-schema.json"
+      },
       "version": "1.0",
       "slug": "content-publish-credential",
       "icon": "📰",
       "discoverable": true
     },
     "w3ccred": "https://www.w3.org/2018/credentials#",
-    "schema-id": "${getSchemaUrl("content-publish-credential", "ld-context-plus")}#",
+    "schema-id": "https://example.com/schemas/content-publish-credential/ld-context.json#",
     "ContentPublishCredential": {
       "@id": "schema-id",
       "@contains": "credentialSubject"
@@ -210,6 +216,10 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
     "@rootType": "ContentPublishCredential",
     "@title": "Content Publish Credential",
     "@metadata": {
+      "uris": {
+        "jsonLdContext": "https://example.com/schemas/content-publish-credential/ld-context.json",
+        "jsonSchema": "https://example.com/schemas/content-publish-credential/json-schema.json"
+      },
       "version": "1.0",
       "slug": "content-publish-credential",
       "icon": "📰",
@@ -217,7 +227,7 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
     },
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "w3ccred": "https://www.w3.org/2018/credentials#",
-    "schema-id": "${getSchemaUrl("content-publish-credential", "ld-context-plus")}#",
+    "schema-id": "https://example.com/schemas/content-publish-credential/ld-context.json#",
     "ContentPublishCredential": {
       "@id": "schema-id",
       "@contains": "credentialSubject"
@@ -240,128 +250,6 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
       "@description": "Data about piece of content this publisher has published",
       "@required": true,
       "@context": {
-        "id": {
-          "@id": "@id",
-          "@type": "xsd:string",
-          "@description": "Globally unique identifier for this piece of content across all versions",
-          "@required": true
-        },
-        "versionId": {
-          "@id": "http://schema.org/version",
-          "@type": "xsd:string",
-          "@description": "Globally unique identifier that refers to this version of this piece of content"
-        },
-        "headline": {
-          "@id": "schema-id:headline",
-          "@type": "xsd:string",
-          "@required": true
-        },
-        "description": {
-          "@id": "schema-id:description",
-          "@type": "xsd:string"
-        },
-        "url": {
-          "@id": "schema-id:url",
-          "@type": "xsd:anyURI",
-          "@required": true
-        },
-        "datePublished": {
-          "@id": "schema-id:date-published",
-          "@type": "xsd:dateTime",
-          "@required": true
-        },
-        "dateModified": {
-          "@id": "schema-id:date-modified",
-          "@type": "xsd:dateTime"
-        },
-        "publisher": {
-          "@id": "schema-id:publisher",
-          "@required": true,
-          "@context": {
-            "id": {
-              "@id": "schema-id:publisher-id",
-              "@type": "xsd:string",
-              "@description": "Publisher DID or other unique identifier URI"
-            },
-            "name": {
-              "@id": "schema-id:publisher-name",
-              "@type": "xsd:string",
-              "@required": true
-            },
-            "url": {
-              "@id": "schema-id:publisher-url",
-              "@type": "xsd:anyURI",
-              "@required": true,
-              "@description": "Publisher homepage"
-            }
-          }
-        },
-        "author": {
-          "@id": "schema-id:author",
-          "@context": {
-            "id": {
-              "@id": "schema-id:publisher-id",
-              "@type": "xsd:string",
-              "@description": "Author DID or other unique identifier URI"
-            },
-            "name": {
-              "@id": "schema-id:author-name",
-              "@type": "xsd:string",
-              "@required": true
-            }
-          }
-        },
-        "keywords": {
-          "@id": "schema-id:keywords",
-          "@type": "xsd:string",
-          "@description": "Comma-separated list of tags/keywords"
-        },
-        "image": {
-          "@id": "schema-id:image",
-          "@type": "xsd:anyURI"
-        },
-        "rawContentUrl": {
-          "@id": "schema-id:raw-content-url",
-          "@type": "xsd:anyURI",
-          "@description": "URL where raw, machine-readable, full text of content can be found (may require authentication)"
-        },
-        "rawContentHash": {
-          "@id": "schema-id:raw-content-hash",
-          "@type": "xsd:string",
-          "@description": "Keccak-256 hash of content at \`rawContentUrl\`"
-        }
-      }
-    }
-  }
-}`,
-  "ContentPublishCredential (flat)": `{
-  "@context": {
-    "@version": 1.1,
-    "@rootType": "ContentPublishCredential",
-    "@title": "Content Publish Credential",
-    "@metadata": {
-      "version": "1.0",
-      "slug": "content-publish-credential",
-      "icon": "📰",
-      "discoverable": true
-    },
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "w3ccred": "https://www.w3.org/2018/credentials#",
-    "schema-id": "${getSchemaUrl("content-publish-credential", "ld-context-plus")}#",
-    "ContentPublishCredential": {
-      "@id": "schema-id",
-      "@contains": "credentialSubject"
-    },
-    "credentialSubject": {
-      "@id": "w3ccred:credentialSubject",
-      "@required": true,
-      "@context": {
-        "publisherId": {
-          "@id": "@id",
-          "@type": "@id",
-          "@description": "Publisher DID",
-          "@required": true
-        },
         "id": {
           "@id": "@id",
           "@type": "xsd:string",
@@ -461,13 +349,17 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
     "@version": 1.1,
     "@rootType": "ContentPublishCredential",
     "@metadata": {
+      "uris": {
+        "jsonLdContext": "https://example.com/schemas/content-publish-credential/ld-context.json",
+        "jsonSchema": "https://example.com/schemas/content-publish-credential/json-schema.json"
+      },
       "version": "1.0",
       "slug": "content-publish-credential",
       "icon": "📰",
       "discoverable": true
     },
     "w3ccred": "https://www.w3.org/2018/credentials#",
-    "schema-id": "${getSchemaUrl("content-publish-credential", "ld-context-plus")}#",
+    "schema-id": "https://example.com/schemas/content-publish-credential/ld-context.json#",
     "ContentPublishCredential": {
       "@id": "schema-id",
       "@contains": "credentialSubject"
@@ -505,6 +397,10 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
     "@title": "Test Credential",
     "@description": "A flat test credential with all of the data types supported by our wizard UIs.",
     "@metadata": {
+      "uris": {
+        "jsonLdContext": "https://example.com/schemas/test-credential/ld-context.json",
+        "jsonSchema": "https://example.com/schemas/test-credential/json-schema.json"
+      },
       "version": "1.0",
       "slug": "test-credential",
       "icon": "🧪",
@@ -512,7 +408,7 @@ export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
     },
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "w3ccred": "https://www.w3.org/2018/credentials#",
-    "schema-id": "${getSchemaUrl("test-credential", "ld-context-plus")}#",
+    "schema-id": "https://example.com/schemas/test-credential/ld-context.json#",
     "TestCredential": {
       "@id": "schema-id",
       "@contains": "credentialSubject"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export * from "./examples";
-export * from "./utils";
 export * from "./VcSchema";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,0 @@
-import { config } from "./config";
-
-export function getSchemaUrl(slug: string, type: "ld-context-plus" | "ld-context" | "json-schema"): string {
-  return `${config.SCHEMA_HOST_URL}/v1/schemas/public/${slug}/${type}.json`;
-}


### PR DESCRIPTION
URLs are now passed into VcSchema directly in the `@metadata` property.