### PR TITLE
Use regular deepdash instead of ES module version

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,4 @@ module.exports = {
   transform: {
     '\\.(ts)$': 'ts-jest'
   },
-  transformIgnorePatterns: [
-    "/node_modules/(?!deepdash-es|lodash-es)"
-  ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/vc-schema-tools",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -22,7 +22,7 @@
   "dependencies": {
     "ajv": "^6.12.3",
     "cross-fetch": "^3.1.4",
-    "deepdash-es": "^5.3.5",
+    "deepdash": "^5.3.9",
     "typescript": "^4.1.3"
   },
   "devDependencies": {
@@ -47,10 +47,5 @@
     "serto-ui": "^0.1.1",
     "styled-components": "^5.1.1",
     "ts-jest": "^26.5.5"
-  },
-  "jest": {
-    "transformIgnorePatterns": [
-      "/node_modules/(?!deepdash-es|lodash-es)"
-    ]
   }
 }

--- a/src/VcSchema.ts
+++ b/src/VcSchema.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 import Ajv from "ajv";
-import { omitDeep, mapValuesDeep } from "deepdash-es/standalone";
+import omitDeep from "deepdash/omitDeep";
+import mapValuesDeep from "deepdash/mapValuesDeep";
 import {
   JsonSchema,
   JsonSchemaNode,
@@ -145,7 +146,7 @@ export class VcSchema {
     // This is a bit of a hack. We want to be able to add JSON Schema info to "@id" properties. To do this we can have LD Context Plus nodes such as `{ "id" : { "@id": "@id", "@required": true } }` which compiles to JSON-LD @context `{ "id" : { "@id": "@id" } }`. This works and simply aliases "id" to "@id". However, the W3C Credentials JSON-LD @context that we import defines `{ @protected: true, "id": "@id" }`. Because of the "@protected" we can't redefine "id" even to an expanded type definition that is functionally identical. So, this mapValuesDeep call replaces `{ "id" : { "@id": "@id" } }` with `{ "id" : "@id" }` which is allowed by "@protected" since it is functionally *and* syntactically the same.
     context = mapValuesDeep(
       context,
-      (value) => {
+      (value: any) => {
         if (value?.["@id"] === "@id") {
           return "@id";
         }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,2 @@
+declare module "deepdash/omitDeep";
+declare module "deepdash/mapValuesDeep";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5950,6 +5950,14 @@ deepdash-es@^5.3.5:
   dependencies:
     lodash-es "^4.17.15"
 
+deepdash@^5.3.9:
+  version "5.3.9"
+  resolved "https://registry.yarnpkg.com/deepdash/-/deepdash-5.3.9.tgz#2aa92570d7b1787ed281e2fafe0be24df00ddfe4"
+  integrity sha512-GRzJ0q9PDj2T+J2fX+b+TlUa2NlZ11l6vJ8LHNKVGeZ8CfxCuJaCychTq07iDRTvlfO8435jlvVS1QXBrW9kMg==
+  dependencies:
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
@@ -9634,6 +9642,11 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
   integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -9679,7 +9692,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.x:
+lodash@4.x, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
This prevents client libraries from having to add deepdash-es to `transformIgnorePatterns` in order to get jest to work. Not sure why I used deepdash-es in the first place last year - main difference I can see is slightly nicer import syntax.