### PR TITLE
Use JSON Schema with inlined LD info as schema source format

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "ajv": "^6.12.3",
+    "@transmute/jsonld-schema": "^0.7.0-unstable.24",
+    "ajv": "^8.7.1",
+    "ajv-formats": "^2.1.1",
     "cross-fetch": "^3.1.4",
-    "deepdash": "^5.3.9",
     "typescript": "^4.1.3"
   },
   "devDependencies": {

--- a/src/VcSchema.ts
+++ b/src/VcSchema.ts
@@ -34,7 +34,9 @@ export class VcSchema {
     }
 
     try {
-      this.jsonLdContext = schemasToContext([jsonSchema]);
+      let vocabUri = this.jsonSchema.$metadata?.uris?.jsonLdContext;
+      vocabUri = vocabUri && vocabUri + "#";
+      this.jsonLdContext = jsonSchemaToNestedContext(this.jsonSchema, vocabUri);
     } catch (err) {
       throw Error("Failed to generate JSON-LD Context from input: " + err.message);
     }

--- a/src/VcSchema.ts
+++ b/src/VcSchema.ts
@@ -1,63 +1,43 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
-import Ajv from "ajv";
-import omitDeep from "deepdash/omitDeep";
-import mapValuesDeep from "deepdash/mapValuesDeep";
-import {
-  JsonSchema,
-  JsonSchemaNode,
-  LdContextPlus,
-  LdContextPlusNode,
-  LdContextPlusRootNode,
-  LdContextPlusInnerNode,
-  LdContextPlusLeafNode,
-} from "./types";
-import { contextPlusFieldsRegexes, jsonLdContextTypeMap, baseVcJsonSchema } from "./helpers";
+import { ValidateFunction } from "ajv";
+import { schemasToContext } from "@transmute/jsonld-schema";
+import { JsonSchema } from "./types";
+import { getNewAjv } from "./helpers";
 
-const ajv = new Ajv();
+const ajv = getNewAjv();
 
 export class VcSchema {
-  public jsonSchemaMessage?: string; // @TODO/tobek This should probably be an array and some of the compilation warnings should get added to it.
-  public schema: LdContextPlus;
-  public jsonLdContext?: any;
-  public jsonSchema?: JsonSchema;
+  public jsonSchema: JsonSchema;
+  public jsonLdContext?: { [key: string]: any };
 
+  private jsonSchemaValidate: ValidateFunction;
   private debugMode?: boolean;
-  private jsonSchemaValidate?: Ajv.ValidateFunction;
 
-  constructor(schema: string | LdContextPlus, debugMode?: boolean) {
+  constructor(jsonSchema: string | JsonSchema, debugMode?: boolean) {
     this.debugMode = debugMode;
-    if (typeof schema === "string") {
+    if (typeof jsonSchema === "string") {
       try {
-        this.schema = JSON.parse(schema);
+        this.jsonSchema = JSON.parse(jsonSchema);
       } catch (err) {
-        throw Error("Failed to parse JSON: " + err.message);
+        throw Error("Failed to parse supplied JSON Schema as JSON: " + err.message);
       }
     } else {
-      this.schema = schema;
+      this.jsonSchema = jsonSchema;
     }
 
-    // @TODO/tobek Should make a JSON Schema for LdContextPlus and validate `this.schema` here and throw an error if invalid.
+    try {
+      ajv.removeSchema(this.jsonSchema?.["$id"]);
+      this.jsonSchemaValidate = ajv.compile(this.jsonSchema);
+    } catch (err) {
+      throw Error("AJV failed to generate validator from supplied JSON Schema: " + err.message);
+    }
 
     try {
-      this.jsonLdContext = this.generateJsonLdContext();
+      this.jsonLdContext = schemasToContext([jsonSchema]);
     } catch (err) {
       throw Error("Failed to generate JSON-LD Context from input: " + err.message);
     }
-
-    try {
-      this.jsonSchema = this.generateJsonSchema();
-      if (this.jsonSchema) {
-        ajv.removeSchema(this.jsonSchema["$id"]);
-        this.jsonSchemaValidate = ajv.compile(this.jsonSchema);
-      }
-    } catch (err) {
-      throw Error("Failed to generate JSON Schema from input: " + err.message);
-    }
-  }
-
-  public getLdContextPlusString(prettyPrint?: boolean): string {
-    return JSON.stringify(this.schema, null, prettyPrint ? 2 : undefined);
   }
 
   public getJsonLdContextString(prettyPrint?: boolean): string {
@@ -65,33 +45,20 @@ export class VcSchema {
   }
 
   public getJsonSchemaString(prettyPrint?: boolean): string {
-    if (!this.jsonSchema) {
-      // @TODO/tobek Should this throw an error? Explanation available in instance.jsonSchemaMessage but that's a bit of a weird paradigm
-      return "";
-    }
     return JSON.stringify(this.jsonSchema, null, prettyPrint ? 2 : undefined);
   }
 
-  public async validateVc(vc: any, cb: (isValid: boolean | null, message?: string) => any): Promise<void> {
-    let vcObj: any;
-    try {
-      vcObj = JSON.parse(vc);
-    } catch (err) {
-      return cb(false, "VC is invalid: Invalid JSON: " + err.message);
-    }
-
-    if (!this.jsonSchema || !this.jsonSchemaValidate) {
-      return cb(null, "VC could not be validated since JSON Schema could not be generated: " + this.jsonSchemaMessage);
-    } else if (
-      this.schema["@context"]?.["@rootType"] &&
-      vcObj.type !== this.schema["@context"]["@rootType"] &&
-      (!Array.isArray(vcObj.type) || vcObj.type.indexOf(this.schema["@context"]["@rootType"]) === -1)
-    ) {
-      // @TODO/tobek A single JSON-LD @context could define multiple VC types but this is set up to recognize exactly one. This could theoretically be expanded - we would probably need to support an array of @rootType's and create a separate JSON Schema for each.
-      return cb(
-        null,
-        `VC could not be validated since it is not of the type "${this.schema["@context"]["@rootType"]}" that we have a schema for.`,
-      );
+  public async validateVc(
+    vc: string | { [key: string]: any },
+    cb: (isValid: boolean | null, message?: string) => any,
+  ): Promise<void> {
+    let vcObj = vc;
+    if (typeof vc === "string") {
+      try {
+        vcObj = JSON.parse(vc);
+      } catch (err) {
+        return cb(false, "VC is invalid: Invalid JSON: " + err.message);
+      }
     }
 
     const isValid = await this.jsonSchemaValidate(vcObj);
@@ -99,8 +66,6 @@ export class VcSchema {
     let message: string;
     if (this.jsonSchemaValidate.errors) {
       message = "VC is invalid: " + JSON.stringify(this.jsonSchemaValidate.errors);
-    } else if (this.jsonSchemaMessage) {
-      message = "VC is valid according to schema, with warnings: " + this.jsonSchemaMessage;
     } else {
       message = "VC is valid according to schema";
     }
@@ -136,184 +101,22 @@ export class VcSchema {
     this.debugMode && console.log(...args);
   }
 
-  private generateJsonLdContext(): any {
-    let context = omitDeep(this.schema, contextPlusFieldsRegexes);
-    if (context["@context"] && !context["@context"]["@version"]) {
-      // Default to JSON-LD proceessing mode version 1.1
-      context["@context"]["@version"] = 1.1;
-    }
-
-    // This is a bit of a hack. We want to be able to add JSON Schema info to "@id" properties. To do this we can have LD Context Plus nodes such as `{ "id" : { "@id": "@id", "@required": true } }` which compiles to JSON-LD @context `{ "id" : { "@id": "@id" } }`. This works and simply aliases "id" to "@id". However, the W3C Credentials JSON-LD @context that we import defines `{ @protected: true, "id": "@id" }`. Because of the "@protected" we can't redefine "id" even to an expanded type definition that is functionally identical. So, this mapValuesDeep call replaces `{ "id" : { "@id": "@id" } }` with `{ "id" : "@id" }` which is allowed by "@protected" since it is functionally *and* syntactically the same.
-    context = mapValuesDeep(
-      context,
-      (value: any) => {
-        if (value?.["@id"] === "@id") {
-          return "@id";
-        }
-        return value;
-      },
-      { callbackAfterIterate: true },
-    );
-
-    return context;
-  }
-
-  private generateJsonSchema(): JsonSchema | undefined {
-    let context = this.schema["@context"] || this.schema;
-    if (Array.isArray(context)) {
-      context = context[context.length - 1];
-    }
-    // @TODO/tobek Handle more complex @context's - merge array of multiple contexts, dereference URLs, etc.
-
-    let parsedSchema: JsonSchemaNode | undefined;
-    const rootType = context["@rootType"];
-    if (typeof context !== "object") {
-      // @TODO/tobek If it's a URL we should fetch that URL
-      this.jsonSchemaMessage = "Invalid LD Context Plus schema: could not find @context object";
-    } else if (!rootType) {
-      this.jsonSchemaMessage =
-        'Invalid LD Context Plus schema: no "@rootType" property. Falling back to base VC schema.';
-    } else if (!context[rootType]) {
-      this.jsonSchemaMessage = `Invalid LD Context Plus schema: "@rootType" property "${rootType}" is not defined. Falling back to base VC schema.`;
-    } else {
-      parsedSchema = this.parseContextPlusNode(context, context[rootType] as LdContextPlusNode, "root");
-    }
-
-    return {
-      $schema: "http://json-schema.org/draft-07/schema#",
-      $id: this.schema["@context"]?.["@metadata"]?.uris?.jsonSchema,
-      $metadata: this.schema["@context"]?.["@metadata"],
-      title: context["@title"],
-      description: context["@description"],
-      ...baseVcJsonSchema,
-      ...parsedSchema,
-      required: Array.from(new Set([...baseVcJsonSchema.required, ...(parsedSchema?.required || [])])),
-      properties: {
-        ...baseVcJsonSchema.properties,
-        ...(parsedSchema?.properties || {}),
-      },
-    };
-  }
-
-  private parseContextPlusNode(
-    context: LdContextPlusRootNode,
-    node: LdContextPlusNode,
-    key: string,
-  ): JsonSchemaNode | undefined {
-    if (typeof node !== "object") {
-      console.warn(
-        `Unsupported LD Context Plus node type at ${key}: node is not an object. Excluding from JSON Schema. Node:`,
-        node,
-      );
-      return;
-    }
-
-    const dataTypeInfo = this.parseContextPlusDataType(node);
-    if (dataTypeInfo) {
-      const leafNode = node as LdContextPlusLeafNode;
-      this.debug(`Parsing "${key}": leaf node`, leafNode);
-      return {
-        title: leafNode["@title"],
-        description: leafNode["@description"],
-        ...dataTypeInfo,
-        ...(leafNode["@format"] && { format: leafNode["@format"] }),
-        ...(leafNode["@items"] && { items: leafNode["@items"] }),
-      };
-    } else {
-      node = node as LdContextPlusInnerNode;
-    }
-
-    const replaceWithType = node["@replaceWith"];
-    if (replaceWithType) {
-      this.debug(`Parsing "${key}": replace with type "${replaceWithType}"`, node);
-      if (!context[replaceWithType]) {
-        console.warn(
-          `Referenced type "${replaceWithType}" could not be found; excluding from JSON Schema. replaceWith from node:`,
-          node,
-        );
-        return;
-      }
-      return this.parseContextPlusNode(context, context[replaceWithType] as LdContextPlusNode, replaceWithType);
-    }
-
-    const nestedProperties = {
-      ...node["@context"],
-    };
-    if (node["@contains"]) {
-      (Array.isArray(node["@contains"]) ? node["@contains"] : [node["@contains"]]).forEach((containedType) => {
-        if (context[containedType]) {
-          nestedProperties[containedType] = context[containedType] as LdContextPlusNode;
-        } else {
-          console.warn(
-            `Referenced type "${containedType}" could not be found; excluding from JSON Schema. Referenced from node:`,
-            node,
-          );
-        }
-      });
-    }
-
-    if (!Object.keys(nestedProperties).length) {
-      console.warn(`Unsupported LD Context Plus node type at ${key}; excluding from JSON Schema. Node:`, node);
-      return;
-    }
-
-    this.debug(`Parsing "${key}": inner @context and/or @contains`, node);
-    const nestedRequired: string[] = [];
-    const parsedNestedProperties: { [key: string]: JsonSchemaNode } = {};
-
-    Object.keys(nestedProperties)
-      .filter((nestedKey) => nestedKey[0] !== "@")
-      .forEach((nestedKey) => {
-        const nestedNode = nestedProperties[nestedKey];
-        const property = this.parseContextPlusNode(context, nestedNode, nestedKey);
-        if (property) {
-          if (
-            nestedNode["@required"] ||
-            ("@replaceWith" in nestedNode &&
-              nestedNode["@replaceWith"] &&
-              (context[nestedNode["@replaceWith"]] as LdContextPlusNode)?.["@required"])
-          ) {
-            nestedRequired.push(nestedKey);
-          }
-          parsedNestedProperties[nestedKey] = property;
-        }
-      });
-
-    return {
-      // Avoid setting these keys to `undefined` which would then override any previously defined values if this node is used with spread operator:
-      ...(node["@title"] && { title: node["@title"] }),
-      ...(node["@description"] && { description: node["@description"] }),
-
-      type: "object",
-      required: nestedRequired.length ? nestedRequired : undefined,
-      properties: parsedNestedProperties,
-    };
-  }
-
-  private parseContextPlusDataType(
-    node: LdContextPlusNode,
-  ): { type: string | string[]; format?: string; items?: JsonSchemaNode } | undefined {
-    if ("@dataType" in node && node["@dataType"]) {
-      return {
-        type: node["@dataType"],
-        format: node["@format"],
-        items: node["@items"],
-      };
-    } else if ("@type" in node && jsonLdContextTypeMap[node["@type"]]) {
-      return jsonLdContextTypeMap[node["@type"]];
-    }
-    return undefined;
-  }
-
   /** Appends our JSON-LD @context to a to the @context of a given VC. */
   private getVcWithSchemaContext(_vc: any): { [key: string]: any } {
     const vc = typeof _vc === "string" ? JSON.parse(_vc) : { ..._vc };
+
+    const schemaContext = this.jsonLdContext?.["@context"];
+    if (!schemaContext) {
+      console.warn("No JSON-LD @context for this schema");
+      return vc;
+    }
+
     if (!vc["@context"]) {
-      vc["@context"] = this.jsonLdContext["@context"];
+      vc["@context"] = schemaContext;
     } else if (Array.isArray(vc["@context"])) {
-      vc["@context"] = vc["@context"].concat(this.jsonLdContext["@context"]);
+      vc["@context"] = vc["@context"].concat(schemaContext);
     } else {
-      vc["@context"] = [vc["@context"]].concat(this.jsonLdContext["@context"]);
+      vc["@context"] = [vc["@context"]].concat(schemaContext);
     }
     return vc;
   }

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -1,4 +1,5 @@
-import { JsonSchema } from "./types";
+import { JsonSchema, VC } from "./types";
+import { baseVcJsonSchema } from "./helpers";
 
 export const EXAMPLE_SCHEMAS: { [key: string]: JsonSchema } = {
   DiplomaCredential: {
@@ -18,35 +19,11 @@ export const EXAMPLE_SCHEMAS: { [key: string]: JsonSchema } = {
     },
     title: "Diploma Credential",
     description: "Credential attesting an alumni's degree from a university.",
-    type: "object",
-    required: ["@context", "type", "issuer", "issuanceDate", "credentialSubject"],
+
+    ...baseVcJsonSchema,
+
     properties: {
-      "@context": {
-        anyOf: [{ type: "string" }, { type: "array" }, { type: "object" }],
-      },
-      id: { type: "string", format: "uri" },
-      type: {
-        anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
-      },
-      issuer: {
-        anyOf: [
-          {
-            type: "string",
-            format: "uri",
-          },
-          {
-            type: "object",
-            required: ["id"],
-            properties: {
-              id: {
-                type: "string",
-                format: "uri",
-              },
-            },
-          },
-        ],
-      },
-      issuanceDate: { type: "string", format: "date-time" },
+      ...baseVcJsonSchema.properties,
       credentialSubject: {
         $comment: '{"term": "credentialSubject", "@id": "https://www.w3.org/2018/credentials#credentialSubject"}',
         type: "object",
@@ -78,7 +55,7 @@ export const EXAMPLE_SCHEMAS: { [key: string]: JsonSchema } = {
             type: "string",
           },
           graduationDate: {
-            $comment: '{"term": "degreeName", "@id": "https://schema.org/Date"}',
+            $comment: '{"term": "graduationDate", "@id": "https://schema.org/Date"}',
             title: "Graduation Date",
             description: "",
             type: "string",
@@ -87,6 +64,241 @@ export const EXAMPLE_SCHEMAS: { [key: string]: JsonSchema } = {
         },
       },
     },
+  },
+  ContentPublishCredential: {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    $id: "https://example.com/schemas/content-publish-credential/ld-context.json",
+    $comment:
+      '{"term": "ContentPublishCredential", "@id": "https://example.com/schemas/content-publish-credential/ld-context.json#"}',
+    $metadata: {
+      uris: {
+        jsonLdContext: "https://example.com/schemas/content-publish-credential/ld-context.json",
+        jsonSchema: "https://example.com/schemas/content-publish-credential/json-schema.json",
+      },
+      version: "1.0",
+      slug: "content-publish-credential",
+      icon: "📰",
+      discoverable: true,
+    },
+    title: "Content Publish Credential",
+    description: "A credential representing a publisher publishing a piece of content such as a news article.",
+
+    ...baseVcJsonSchema,
+
+    properties: {
+      ...baseVcJsonSchema.properties,
+      credentialSubject: {
+        $comment: '{"term": "credentialSubject", "@id": "https://www.w3.org/2018/credentials#credentialSubject"}',
+        type: "object",
+        required: ["id", "publishedContent"],
+        properties: {
+          id: {
+            $comment: '{"term": "id", "@id": "@id"}',
+            description: "Publisher DID",
+            type: "string",
+            format: "uri",
+          },
+          publishedContent: {
+            $comment: '{"term": "publishedContent", "@id": "publishedContent"}',
+            type: "object",
+            required: ["id", "headline", "url", "datePublished", "publisher"],
+            properties: {
+              id: {
+                $comment: '{"term": "id", "@id": "@id"}',
+                description: "Globally unique identifier for this piece of content across all versions",
+                type: "string",
+              },
+              versionId: {
+                $comment: '{"term": "versionId", "@id": "http://schema.org/version"}',
+                description: "Globally unique identifier that refers to this version of this piece of content",
+                type: "string",
+              },
+              headline: {
+                $comment: '{"term": "headline", "@id": "https://schema.org/headline"}',
+                type: "string",
+              },
+              description: {
+                $comment: '{"term": "description", "@id": "https://schema.org/description"}',
+                type: "string",
+              },
+              url: {
+                $comment: '{"term": "url", "@id": "https://schema.org/URL"}',
+                type: "string",
+                format: "uri",
+              },
+              datePublished: {
+                $comment: '{"term": "datePublished", "@id": "https://schema.org/datePublished"}',
+                type: "string",
+                format: "date-time",
+              },
+              dateModified: {
+                $comment: '{"term": "dateModified", "@id": "https://schema.org/dateModified"}',
+                type: "string",
+                format: "date-time",
+              },
+              publisher: {
+                $comment: '{"term": "publisher", "@id": "https://schema.org/publisher"}',
+                type: "object",
+                required: ["name", "url"],
+                properties: {
+                  id: {
+                    $comment: '{"term": "id", "@id": "@id"}',
+                    description: "Publisher DID or other unique identifier URI",
+                    type: "string",
+                    format: "uri",
+                  },
+                  name: {
+                    $comment: '{"term": "name", "@id": "http://schema.org/name"}',
+                    type: "string",
+                  },
+                  url: {
+                    $comment: '{"term": "url", "@id": "https://schema.org/URL"}',
+                    description: "Publisher homepage",
+                    type: "string",
+                    format: "uri",
+                  },
+                },
+              },
+              author: {
+                $comment: '{"term": "author", "@id": "https://schema.org/author"}',
+                type: "object",
+                required: ["name"],
+                properties: {
+                  id: {
+                    $comment: '{"term": "id", "@id": "@id"}',
+                    description: "Author DID or other unique identifier URI",
+                    type: "string",
+                    format: "uri",
+                  },
+                  name: {
+                    $comment: '{"term": "name", "@id": "http://schema.org/name"}',
+                    type: "string",
+                  },
+                },
+              },
+              keywords: {
+                $comment: '{"term": "keywords", "@id": "http://schema.org/keywords"}',
+                description: "Comma-separated list of tags/keywords",
+                type: "string",
+              },
+              image: {
+                $comment: '{"term": "image", "@id": "http://schema.org/image"}',
+                type: "string",
+                format: "uri",
+              },
+              rawContentUrl: {
+                $comment: '{"term": "rawContentUrl", "@id": "http://schema.org/URL"}',
+                description:
+                  "URL where raw, machine-readable, full text of content can be found (may require authentication)",
+                type: "string",
+                format: "uri",
+              },
+              rawContentHash: {
+                $comment: '{"term": "rawContentHash", "@id": "http://schema.org/Text"}',
+                description: "Keccak-256 hash of content at `rawContentUrl`",
+                type: "string",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  TestCredential: {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    $id: "https://example.com/schemas/test-credential/json-schema.json",
+    $comment: '{"term": "TestCredential", "@id": "https://example.com/schemas/test-credential/ld-context.json#"}',
+    $metadata: {
+      uris: {
+        jsonLdContext: "https://example.com/schemas/test-credential/ld-context.json",
+        jsonSchema: "https://example.com/schemas/test-credential/json-schema.json",
+      },
+      version: "1.0",
+      slug: "test-credential",
+      icon: "🧪",
+      discoverable: true,
+    },
+    title: "Test Credential",
+    description: "A flat test credential with all of the data types supported by our wizard UIs.",
+
+    ...baseVcJsonSchema,
+
+    properties: {
+      ...baseVcJsonSchema.properties,
+      credentialSubject: {
+        $comment: '{"term": "credentialSubject", "@id": "https://www.w3.org/2018/credentials#credentialSubject"}',
+        type: "object",
+        required: ["id", "headline", "url", "date"],
+        properties: {
+          id: {
+            $comment: '{"term": "id", "@id": "@id"}',
+            title: "Credential Subject ID",
+            description: "Globally unique identifier for the piece of content this credential is about",
+            type: "string",
+            format: "uri",
+          },
+          headline: {
+            $comment: '{"term": "headline", "@id": "https://schema.org/Text"}',
+            title: "Headline",
+            type: "string",
+          },
+          description: {
+            $comment: '{"term": "description", "@id": "https://schema.org/Text"}',
+            title: "Description",
+            type: "string",
+          },
+          url: {
+            $comment: '{"term": "url", "@id": "https://schema.org/URL"}',
+            title: "URL",
+            type: "string",
+            format: "uri",
+          },
+          dateTime: {
+            $comment: '{"term": "dateTime", "@id": "https://schema.org/DateTime"}',
+            title: "Date & Time",
+            type: "string",
+            format: "date-time",
+          },
+          date: {
+            $comment: '{"term": "date", "@id": "https://schema.org/Date"}',
+            title: "Date",
+            type: "string",
+            format: "date",
+          },
+          author: {
+            $comment: '{"term": "author", "@id": "author"}',
+            title: "Author",
+            type: "object",
+            required: ["name"],
+            properties: {
+              id: {
+                $comment: '{"term": "id", "@id": "publisher-id"}',
+                description: "Author DID or other unique identifier URI",
+                type: "string",
+              },
+              name: {
+                $comment: '{"term": "name", "@id": "author-name"}',
+                type: "string",
+              },
+            },
+          },
+          opinion: {
+            $comment: '{"term": "opinion", "@id": "https://schema.org/Boolean"}',
+            title: "Opinion",
+            type: "boolean",
+          },
+          numRevisions: {
+            $comment: '{"term": "numRevisions", "@id": "https://schema.org/Number"}',
+            title: "Number of Revisions",
+            type: "number",
+          },
+        },
+      },
+    },
+  },
+  "[no schema]": {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    ...baseVcJsonSchema,
   },
 };
 
@@ -297,186 +509,6 @@ export const EXAMPLE_JSON_LD_SCHEMAS: { [key: string]: string } = {
       "@description": "Data about piece of content this publisher has published",
       "@required": true,
       "@replaceWith": "Article"
-    }
-  }
-}`,
-  "ContentPublishCredential (programmatic)": `{
-  "@context": {
-    "@version": 1.1,
-    "@rootType": "ContentPublishCredential",
-    "@title": "Content Publish Credential",
-    "@metadata": {
-      "uris": {
-        "jsonLdContext": "https://example.com/schemas/content-publish-credential/ld-context.json",
-        "jsonSchema": "https://example.com/schemas/content-publish-credential/json-schema.json"
-      },
-      "version": "1.0",
-      "slug": "content-publish-credential",
-      "icon": "📰",
-      "discoverable": true
-    },
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "w3ccred": "https://www.w3.org/2018/credentials#",
-    "schema-id": "https://example.com/schemas/content-publish-credential/ld-context.json#",
-    "ContentPublishCredential": {
-      "@id": "schema-id",
-      "@contains": "credentialSubject"
-    },
-    "credentialSubject": {
-      "@id": "w3ccred:credentialSubject",
-      "@required": true,
-      "@contains": "publishedContent",
-      "@context": {
-        "id": {
-          "@id": "@id",
-          "@type": "@id",
-          "@description": "Publisher DID",
-          "@required": true
-        }
-      }
-    },
-    "publishedContent": {
-      "@id": "schema-id:publishedContent",
-      "@description": "Data about piece of content this publisher has published",
-      "@required": true,
-      "@context": {
-        "id": {
-          "@id": "@id",
-          "@type": "xsd:string",
-          "@description": "Globally unique identifier for this piece of content across all versions",
-          "@required": true
-        },
-        "versionId": {
-          "@id": "http://schema.org/version",
-          "@type": "xsd:string",
-          "@description": "Globally unique identifier that refers to this version of this piece of content"
-        },
-        "headline": {
-          "@id": "schema-id:headline",
-          "@type": "xsd:string",
-          "@required": true
-        },
-        "description": {
-          "@id": "schema-id:description",
-          "@type": "xsd:string"
-        },
-        "url": {
-          "@id": "schema-id:url",
-          "@type": "xsd:anyURI",
-          "@required": true
-        },
-        "datePublished": {
-          "@id": "schema-id:date-published",
-          "@type": "xsd:dateTime",
-          "@required": true
-        },
-        "dateModified": {
-          "@id": "schema-id:date-modified",
-          "@type": "xsd:dateTime"
-        },
-        "publisher": {
-          "@id": "schema-id:publisher",
-          "@required": true,
-          "@context": {
-            "id": {
-              "@id": "schema-id:publisher-id",
-              "@type": "xsd:string",
-              "@description": "Publisher DID or other unique identifier URI"
-            },
-            "name": {
-              "@id": "schema-id:publisher-name",
-              "@type": "xsd:string",
-              "@required": true
-            },
-            "url": {
-              "@id": "schema-id:publisher-url",
-              "@type": "xsd:anyURI",
-              "@required": true,
-              "@description": "Publisher homepage"
-            }
-          }
-        },
-        "author": {
-          "@id": "schema-id:author",
-          "@context": {
-            "id": {
-              "@id": "schema-id:publisher-id",
-              "@type": "xsd:string",
-              "@description": "Author DID or other unique identifier URI"
-            },
-            "name": {
-              "@id": "schema-id:author-name",
-              "@type": "xsd:string",
-              "@required": true
-            }
-          }
-        },
-        "keywords": {
-          "@id": "schema-id:keywords",
-          "@type": "xsd:string",
-          "@description": "Comma-separated list of tags/keywords"
-        },
-        "image": {
-          "@id": "schema-id:image",
-          "@type": "xsd:anyURI"
-        },
-        "rawContentUrl": {
-          "@id": "schema-id:raw-content-url",
-          "@type": "xsd:anyURI",
-          "@description": "URL where raw, machine-readable, full text of content can be found (may require authentication)"
-        },
-        "rawContentHash": {
-          "@id": "schema-id:raw-content-hash",
-          "@type": "xsd:string",
-          "@description": "Keccak-256 hash of content at \`rawContentUrl\`"
-        }
-      }
-    }
-  }
-}`,
-  "ContentPublishCredential (minimal)": `{
-  "@context": {
-    "@version": 1.1,
-    "@rootType": "ContentPublishCredential",
-    "@metadata": {
-      "uris": {
-        "jsonLdContext": "https://example.com/schemas/content-publish-credential/ld-context.json",
-        "jsonSchema": "https://example.com/schemas/content-publish-credential/json-schema.json"
-      },
-      "version": "1.0",
-      "slug": "content-publish-credential",
-      "icon": "📰",
-      "discoverable": true
-    },
-    "w3ccred": "https://www.w3.org/2018/credentials#",
-    "schema-id": "https://example.com/schemas/content-publish-credential/ld-context.json#",
-    "ContentPublishCredential": {
-      "@id": "schema-id",
-      "@contains": "credentialSubject"
-    },
-    "credentialSubject": {
-      "@id": "w3ccred:credentialSubject",
-      "@required": true,
-      "@contains": "publishedContent",
-      "@context": {
-        "id": {
-          "@id": "@id",
-          "@type": "@id",
-          "@required": true
-        }
-      }
-    },
-    "publishedContent": {
-      "@id": "schema-id:publishedContent",
-      "@description": "Data about piece of content this publisher has published",
-      "@required": true,
-      "@context": {
-        "url": {
-          "@id": "http://schema.org/url",
-          "@type": "http://schema.org/URL",
-          "@required": true
-        }
-      }
     }
   }
 }`,
@@ -809,130 +841,79 @@ export const EXAMPLE_JSON_LD_SCHEMAS: { [key: string]: string } = {
     "proof": {"@id": "https://w3id.org/security#proof", "@type": "@id", "@container": "@graph"}
   }
 }`,
-  "[no schema]": `{}`,
 };
 
-export const EXAMPLE_VCS: { [key: string]: string } = {
-  DiplomaCredential: `{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://beta.api.schemas.serto.id/v1/public/diploma-credential/1.2/ld-context.json"
-  ],
-  "type": ["VerifiableCredential", "DiplomaCredential"],
-  "issuer": { "id": "did:web:beta.agent.serto.id" },
-  "issuanceDate": "2021-10-13T21:57:34.000Z",
-  "credentialSubject": {
-    "id": "did:ethr:0x02f4b0ceed160cccb47a66951baffac8a8ace75c33b761beb545e3ec99f44300fc",
-    "degreeName": "Bachelor of Science in Examples",
-    "universityName": "Example University",
-    "graduationDate": "2012-10-31",
-    "universityId": "did:ethr:rinkeby:0x9fb04797cc0b1711c86b960105e0c3ed3f9cb749"
+export const EXAMPLE_VCS: { [key: string]: VC } = {
+  DiplomaCredential: {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://beta.api.schemas.serto.id/v1/public/diploma-credential/1.2/ld-context.json",
+    ],
+    type: ["VerifiableCredential", "DiplomaCredential"],
+    issuer: { id: "did:web:beta.agent.serto.id" },
+    issuanceDate: "2021-10-13T21:57:34.000Z",
+    credentialSubject: {
+      id: "did:ethr:0x02f4b0ceed160cccb47a66951baffac8a8ace75c33b761beb545e3ec99f44300fc",
+      degreeName: "Bachelor of Science in Examples",
+      universityName: "Example University",
+      graduationDate: "2012-10-31",
+      universityId: "did:ethr:rinkeby:0x9fb04797cc0b1711c86b960105e0c3ed3f9cb749",
+    },
+    credentialSchema: {
+      id: "https://beta.api.schemas.serto.id/v1/public/diploma-credential/1.2/json-schema.json",
+      type: "JsonSchemaValidator2018",
+    },
+    proof: {
+      type: "JwtProof2020",
+      jwt:
+        "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJ1bml2ZXJzaXR5SWQiOiJkaWQ6ZXRocjpyaW5rZWJ5OjB4OWZiMDQ3OTdjYzBiMTcxMWM4NmI5NjAxMDVlMGMzZWQzZjljYjc0OSIsInVuaXZlcnNpdHlOYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5IiwiZ3JhZHVhdGlvbkRhdGUiOiIyMDEyLTEwLTMxIiwiZGVncmVlTmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgaW4gRXhhbXBsZXMifSwiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL2JldGEuYXBpLnNjaGVtYXMuc2VydG8uaWQvdjEvcHVibGljL2RpcGxvbWEtY3JlZGVudGlhbC8xLjIvbGQtY29udGV4dC5qc29uIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJEaXBsb21hQ3JlZGVudGlhbCJdfSwiY3JlZGVudGlhbFNjaGVtYSI6eyJpZCI6Imh0dHBzOi8vYmV0YS5hcGkuc2NoZW1hcy5zZXJ0by5pZC92MS9wdWJsaWMvZGlwbG9tYS1jcmVkZW50aWFsLzEuMi9qc29uLXNjaGVtYS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWFWYWxpZGF0b3IyMDE4In0sInN1YiI6ImRpZDpldGhyOjB4MDJmNGIwY2VlZDE2MGNjY2I0N2E2Njk1MWJhZmZhYzhhOGFjZTc1YzMzYjc2MWJlYjU0NWUzZWM5OWY0NDMwMGZjIiwibmJmIjoxNjM0MTYyMjU0LCJpc3MiOiJkaWQ6d2ViOmJldGEuYWdlbnQuc2VydG8uaWQifQ.GHlgeeT0BsqbAm5ZDKBoNLqE6wn5AoBywdscGK5mIV1OUAymkhxAjzeuJhFvsoW0kJl56Vq1JIVOAGqCsM6x5w",
+    },
   },
-  "credentialSchema": {
-    "id": "https://beta.api.schemas.serto.id/v1/public/diploma-credential/1.2/json-schema.json",
-    "type": "JsonSchemaValidator2018"
+  ContentPublishCredential: {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://example.com/schemas/content-publish-credential/ld-context.json",
+    ],
+    id: "did:example:publisher-did#credential-id",
+    type: ["VerifiableCredential", "ContentPublishCredential"],
+    issuer: "did:example:publisher-did",
+    issuanceDate: "2017-12-05T14:27:42Z",
+    credentialSubject: {
+      id: "did:example:publisher-did",
+      publishedContent: {
+        "@type": "Article",
+        id: "did:example:publisher-did#article-id",
+        versionId: "did:example:publisher-did#article-version-id",
+        headline: "A Very Important Article",
+        description: "This important article covers important things you should know about.",
+        url: "https://example-publisher.com/articles/a-very-important-article",
+        datePublished: "2020-06-29T00:04:12.418Z",
+        dateModified: "2020-06-30T00:10:45.000Z",
+        image: "https://example-publisher.com/images/important-article-primary-image.jpg",
+        rawContentUrl: "https://example-publisher.com/raw-content?id=did:example:publisher-did#article-id",
+        rawContentHash: "0x123abc",
+        keywords: "news, breaking news, politics",
+        publisher: {
+          id: "did:example:publisher-did",
+          type: "Organization",
+          name: "Example Publisher",
+          url: "https://example-publisher.com/",
+        },
+        author: {
+          id: "did:example:publisher-did#author-id",
+          type: "Person",
+          name: "Joe Reporter",
+        },
+      },
+    },
   },
-  "proof": {
-    "type": "JwtProof2020",
-    "jwt": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJ1bml2ZXJzaXR5SWQiOiJkaWQ6ZXRocjpyaW5rZWJ5OjB4OWZiMDQ3OTdjYzBiMTcxMWM4NmI5NjAxMDVlMGMzZWQzZjljYjc0OSIsInVuaXZlcnNpdHlOYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5IiwiZ3JhZHVhdGlvbkRhdGUiOiIyMDEyLTEwLTMxIiwiZGVncmVlTmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgaW4gRXhhbXBsZXMifSwiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL2JldGEuYXBpLnNjaGVtYXMuc2VydG8uaWQvdjEvcHVibGljL2RpcGxvbWEtY3JlZGVudGlhbC8xLjIvbGQtY29udGV4dC5qc29uIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJEaXBsb21hQ3JlZGVudGlhbCJdfSwiY3JlZGVudGlhbFNjaGVtYSI6eyJpZCI6Imh0dHBzOi8vYmV0YS5hcGkuc2NoZW1hcy5zZXJ0by5pZC92MS9wdWJsaWMvZGlwbG9tYS1jcmVkZW50aWFsLzEuMi9qc29uLXNjaGVtYS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWFWYWxpZGF0b3IyMDE4In0sInN1YiI6ImRpZDpldGhyOjB4MDJmNGIwY2VlZDE2MGNjY2I0N2E2Njk1MWJhZmZhYzhhOGFjZTc1YzMzYjc2MWJlYjU0NWUzZWM5OWY0NDMwMGZjIiwibmJmIjoxNjM0MTYyMjU0LCJpc3MiOiJkaWQ6d2ViOmJldGEuYWdlbnQuc2VydG8uaWQifQ.GHlgeeT0BsqbAm5ZDKBoNLqE6wn5AoBywdscGK5mIV1OUAymkhxAjzeuJhFvsoW0kJl56Vq1JIVOAGqCsM6x5w"
-  }
-}`,
-  ContentPublishCredential: `{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://example.com/schemas/content-publish-credential/ld-context.json"
-  ],
-  "id": "did:example:publisher-did#credential-id",
-  "type": ["VerifiableCredential", "ContentPublishCredential"],
-  "issuer": "did:example:publisher-did",
-  "issuanceDate": "2017-12-05T14:27:42Z",
-  "credentialSubject": {
-    "id": "did:example:publisher-did",
-    "publishedContent": {
-      "@type": "Article",
-      "id": "did:example:publisher-did#article-id",
-      "versionId": "did:example:publisher-did#article-version-id",
-      "headline": "A Very Important Article",
-      "description": "This important article covers important things you should know about.",
-      "url": "https://example-publisher.com/articles/a-very-important-article",
-      "datePublished": "2020-06-29T00:04:12.418Z",
-      "dateModified": "2020-06-30T00:10:45.000Z",
-      "image": "https://example-publisher.com/images/important-article-primary-image.jpg",
-      "rawContentUrl": "https://example-publisher.com/raw-content?id=did:example:publisher-did#article-id",
-      "rawContentHash": "0x123abc",
-      "keywords": "news, breaking news, politics",
-      "publisher": {
-        "id": "did:example:publisher-did",
-        "type": "Organization",
-        "name": "Example Publisher",
-        "url": "https://example-publisher.com/"
-      },
-      "author": {
-        "id": "did:example:publisher-did#author-id",
-        "type": "Person",
-        "name": "Joe Reporter"
-      }
-    }
-  }
-}`,
-  "ContentPublishCredential (programmatic)": `{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1"
-  ],
-  "id": "did:example:publisher-did#credential-id",
-  "type": ["VerifiableCredential", "ContentPublishCredential"],
-  "issuer": "did:example:publisher-did",
-  "issuanceDate": "2017-12-05T14:27:42Z",
-  "credentialSubject": {
-    "id": "did:example:publisher-did",
-    "publishedContent": {
-      "id": "did:example:publisher-did#article-id",
-      "versionId": "did:example:publisher-did#article-version-id",
-      "headline": "A Very Important Article",
-      "description": "This important article covers important things you should know about.",
-      "url": "https://example-publisher.com/articles/a-very-important-article",
-      "datePublished": "2020-06-29T00:04:12.418Z",
-      "dateModified": "2020-06-30T00:10:45.000Z",
-      "image": "https://example-publisher.com/images/important-article-primary-image.jpg",
-      "rawContentUrl": "https://example-publisher.com/raw-content?id=did:example:publisher-did#article-id",
-      "rawContentHash": "0x123abc",
-      "keywords": "news, breaking news, politics",
-      "publisher": {
-        "id": "did:example:publisher-did",
-        "name": "Example Publisher",
-        "url": "https://example-publisher.com/"
-      },
-      "author": {
-        "id": "did:example:publisher-did#author-id",
-        "name": "Joe Reporter"
-      }
-    }
-  }
-}`,
-  "ContentPublishCredential (minimal)": `{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1"
-  ],
-  "id": "did:example:publisher-did#credential-id",
-  "type": ["VerifiableCredential", "ContentPublishCredential"],
-  "issuer": "did:example:publisher-did",
-  "issuanceDate": "2017-12-05T14:27:42Z",
-  "credentialSubject": {
-    "id": "did:example:publisher-did",
-    "publishedContent": {
-      "url": "https://example-publisher.com/articles/a-very-important-article"
-    }
-  }
-}`,
-  "[no schema]": `{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1"
-  ],
-  "type": ["VerifiableCredential"],
-  "issuer": "did:example:publisher-did",
-  "issuanceDate": "2017-12-05T14:27:42Z",
-  "credentialSubject": {
-    "hi there": "these are the minimum required properties for all VCs - if you remove any, this VC won't validate"
-  }
-}`,
+  "[no schema]": {
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    type: ["VerifiableCredential"],
+    issuer: "did:example:publisher-did",
+    issuanceDate: "2017-12-05T14:27:42Z",
+    credentialSubject: {
+      "hi there": "these are the minimum required properties for all VCs - if you remove any, this VC won't validate",
+    },
+  },
 };

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -1,4 +1,96 @@
-export const EXAMPLE_SCHEMAS: { [key: string]: string } = {
+import { JsonSchema } from "./types";
+
+export const EXAMPLE_SCHEMAS: { [key: string]: JsonSchema } = {
+  DiplomaCredential: {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    $id: "https://beta.api.schemas.serto.id/v1/public/diploma-credential/json-schema.json",
+    $comment:
+      '{"term": "DiplomaCredential", "@id": "https://beta.api.schemas.serto.id/v1/public/diploma-credential/ld-context.json#"}',
+    $metadata: {
+      uris: {
+        jsonLdContext: "https://beta.api.schemas.serto.id/v1/public/diploma-credential/ld-context.json",
+        jsonSchema: "https://beta.api.schemas.serto.id/v1/public/diploma-credential/json-schema.json",
+      },
+      version: "1.0",
+      slug: "diploma-credential",
+      icon: "🎓",
+      discoverable: true,
+    },
+    title: "Diploma Credential",
+    description: "Credential attesting an alumni's degree from a university.",
+    type: "object",
+    required: ["@context", "type", "issuer", "issuanceDate", "credentialSubject"],
+    properties: {
+      "@context": {
+        anyOf: [{ type: "string" }, { type: "array" }, { type: "object" }],
+      },
+      id: { type: "string", format: "uri" },
+      type: {
+        anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+      },
+      issuer: {
+        anyOf: [
+          {
+            type: "string",
+            format: "uri",
+          },
+          {
+            type: "object",
+            required: ["id"],
+            properties: {
+              id: {
+                type: "string",
+                format: "uri",
+              },
+            },
+          },
+        ],
+      },
+      issuanceDate: { type: "string", format: "date-time" },
+      credentialSubject: {
+        $comment: '{"term": "credentialSubject", "@id": "https://www.w3.org/2018/credentials#credentialSubject"}',
+        type: "object",
+        required: ["id", "universityName", "degreeName"],
+        properties: {
+          id: {
+            $comment: '{"term": "id", "@id": "@id"}',
+            title: "Alumni ID",
+            type: "string",
+            format: "uri",
+          },
+          universityId: {
+            $comment: '{"term": "universityId", "@id": "@id"}',
+            title: "University ID",
+            description: "",
+            type: "string",
+            format: "uri",
+          },
+          universityName: {
+            $comment: '{"term": "universityName", "@id": "https://schema.org/Text"}',
+            title: "University Name",
+            description: "",
+            type: "string",
+          },
+          degreeName: {
+            $comment: '{"term": "degreeName", "@id": "https://schema.org/Text"}',
+            title: "Degree Name",
+            description: 'E.g. "Bachelor of Arts in Astrophysics"',
+            type: "string",
+          },
+          graduationDate: {
+            $comment: '{"term": "degreeName", "@id": "https://schema.org/Date"}',
+            title: "Graduation Date",
+            description: "",
+            type: "string",
+            format: "date",
+          },
+        },
+      },
+    },
+  },
+};
+
+export const EXAMPLE_JSON_LD_SCHEMAS: { [key: string]: string } = {
   DiplomaCredential: `{
   "@context": {
     "@version": 1.1,
@@ -843,43 +935,4 @@ export const EXAMPLE_VCS: { [key: string]: string } = {
     "hi there": "these are the minimum required properties for all VCs - if you remove any, this VC won't validate"
   }
 }`,
-};
-
-export const EXAMPLE_JSON_SCHEMAS = {
-  DiplomaCredential: {
-    $schema: "http://json-schema.org/draft-07/schema#",
-    $id: "https://beta.api.schemas.serto.id/v1/public/diploma-credential/json-schema.json",
-    title: "Diploma Credential",
-    description: "Credential attesting an alumni's degree from a university.",
-    type: "object",
-    required: ["@context", "type", "issuer", "issuanceDate", "credentialSubject"],
-    properties: {
-      "@context": { type: ["string", "array", "object"] },
-      id: { type: "string", format: "uri" },
-      type: { type: ["string", "array"], items: { type: "string" } },
-      issuer: {
-        type: ["string", "object"],
-        format: "uri",
-        required: ["id"],
-        properties: {
-          id: {
-            type: "string",
-            format: "uri",
-          },
-        },
-      },
-      issuanceDate: { type: "string", format: "date-time" },
-      credentialSubject: {
-        type: "object",
-        required: ["id", "universityName", "degreeName"],
-        properties: {
-          id: { title: "Alumni ID", type: "string", format: "uri" },
-          universityId: { title: "University ID", description: "", type: "string", format: "uri" },
-          universityName: { title: "University Name", description: "", type: "string" },
-          degreeName: { title: "Degree Name", description: 'E.g. "Bachelor of Arts in Astrophysics"', type: "string" },
-          graduationDate: { title: "Graduation Date", description: "", type: "string", format: "date" },
-        },
-      },
-    },
-  },
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,6 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+
 /** Fields valid in JSON-LD Context Plus that are not valid in JSON-LD Context. */
 export const contextPlusFields = [
   "@rootType",
@@ -33,28 +36,32 @@ export const baseVcJsonSchema = {
   required: ["@context", "type", "issuer", "issuanceDate", "credentialSubject"],
   properties: {
     "@context": {
-      type: ["string", "array", "object"],
+      anyOf: [{ type: "string" }, { type: "array" }, { type: "object" }],
     },
     id: {
       type: "string",
       format: "uri",
     },
     type: {
-      type: ["string", "array"],
-      items: {
-        type: "string",
-      },
+      anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
     },
     issuer: {
-      type: ["string", "object"],
-      format: "uri",
-      required: ["id"],
-      properties: {
-        id: {
+      anyOf: [
+        {
           type: "string",
           format: "uri",
         },
-      },
+        {
+          type: "object",
+          required: ["id"],
+          properties: {
+            id: {
+              type: "string",
+              format: "uri",
+            },
+          },
+        },
+      ],
     },
     issuanceDate: {
       type: "string",
@@ -87,4 +94,11 @@ export const baseVcJsonSchema = {
       },
     },
   },
+};
+
+export const getNewAjv = (): Ajv => {
+  const ajv = new Ajv();
+  ajv.addKeyword("$metadata");
+  addFormats(ajv);
+  return ajv;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,56 +15,16 @@ export interface VC {
 
 export interface DefaultSchemaMetadata {
   uris?: {
-    jsonLdContextPlus?: string;
     jsonLdContext?: string;
     jsonSchema?: string;
   };
+  [key: string]: any;
 }
-
-export interface LdContextPlus<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> {
-  "@context": LdContextPlusRootNode<MetadataType>;
-}
-
-export interface LdContextPlusRootNode<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> {
-  "@rootType": string;
-  "@id"?: string;
-  "@title"?: string;
-  "@description"?: string;
-  "@metadata"?: MetadataType;
-  [key: string]: LdContextPlusNode<MetadataType> | MetadataType | number | string | undefined;
-}
-
-export interface LdContextPlusInnerNode<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> {
-  "@id": string;
-  "@contains"?: string;
-  "@replaceWith"?: string;
-  "@title"?: string;
-  "@description"?: string;
-  "@required"?: boolean;
-  "@metadata"?: MetadataType;
-  "@context"?: { [key: string]: LdContextPlusNode<MetadataType> };
-}
-
-export interface LdContextPlusLeafNode<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> {
-  "@id": string;
-  "@type": string;
-  "@dataType"?: string;
-  "@format"?: string;
-  "@title"?: string;
-  "@description"?: string;
-  "@required"?: boolean;
-  "@metadata"?: MetadataType;
-  "@items"?: JsonSchemaNode;
-}
-
-export type LdContextPlusNodeKey = keyof LdContextPlusLeafNode | keyof LdContextPlusInnerNode;
-
-export type LdContextPlusNode<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> =
-  | LdContextPlusInnerNode<MetadataType>
-  | LdContextPlusLeafNode<MetadataType>;
 
 export interface JsonSchemaNode {
-  type: string | string[];
+  $comment?: string;
+  type?: string | string[];
+  anyOf?: JsonSchemaNode[];
   properties?: { [key: string]: JsonSchemaNode };
   title?: string;
   description?: string;
@@ -72,8 +32,9 @@ export interface JsonSchemaNode {
   items?: JsonSchemaNode;
   required?: string[];
 }
-export interface JsonSchema extends JsonSchemaNode {
+export interface JsonSchema<MetadataType extends DefaultSchemaMetadata = DefaultSchemaMetadata> extends JsonSchemaNode {
   $schema: string;
   $id?: string;
+  $metadata?: MetadataType;
   [key: string]: any;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,16 @@
 /** Quick n dirty VC type with properties we need, the full W3C VC spec has much much more. */
 export interface VC {
   "@context": string | string[];
+  id?: string;
   type: string[];
   issuer: string | { id: string; [key: string]: any };
   issuanceDate: string;
   expirationDate?: string;
   credentialSubject: { [key: string]: any };
-  proof: { jwt: string };
+  proof?: {
+    type?: string;
+    jwt: string;
+  };
   credentialSchema?: {
     id: string;
     type: string;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,2 +1,0 @@
-declare module "deepdash/omitDeep";
-declare module "deepdash/mapValuesDeep";

--- a/src/validateVc.test.ts
+++ b/src/validateVc.test.ts
@@ -1,14 +1,14 @@
 import "jest";
 import fetchMock from "jest-fetch-mock";
 import { validateVc } from "./validateVc";
-import { EXAMPLE_VCS, EXAMPLE_JSON_SCHEMAS } from "./examples";
+import { EXAMPLE_VCS, EXAMPLE_SCHEMAS } from "./examples";
 
 const vcString = EXAMPLE_VCS.DiplomaCredential;
 const vc = JSON.parse(EXAMPLE_VCS.DiplomaCredential);
 
 beforeEach(() => {
   fetchMock.enableMocks();
-  fetchMock.mockResponse(JSON.stringify(EXAMPLE_JSON_SCHEMAS.DiplomaCredential));
+  fetchMock.mockResponse(JSON.stringify(EXAMPLE_SCHEMAS.DiplomaCredential));
 });
 
 it("should fail on invalid JSON string", async () => {
@@ -65,7 +65,7 @@ it("should fail on missing `credentialSchema.id`", async () => {
   expect(warnings.length).toBe(1);
   expect(warnings[0]).toMatch(/"credentialSchema.id" property not found/);
   expect(errors.length).toBe(1);
-  expect(errors[0]).toMatch(/should have required property 'id'/);
+  expect(errors[0]).toMatch(/must have required property 'id'/);
 });
 
 it("should warn on failure to fetch JSON Schema", async () => {
@@ -95,7 +95,7 @@ it("should detect missing property from base VC schema even if no JSON Schema pr
   expect(warnings.length).toBe(1);
   expect(warnings[0]).toMatch(/No "credentialSchema" property found/);
   expect(errors.length).toBe(1);
-  expect(errors[0]).toMatch(/should have required property '@context'/);
+  expect(errors[0]).toMatch(/must have required property '@context'/);
 });
 
 it("should detect missing property from JSON Schema", async () => {
@@ -109,5 +109,5 @@ it("should detect missing property from JSON Schema", async () => {
   expect(valid).toBe(false);
   expect(warnings.length).toBe(0);
   expect(errors.length).toBe(1);
-  expect(errors[0]).toMatch(/should have required property 'universityName'/);
+  expect(errors[0]).toMatch(/must have required property 'universityName'/);
 });

--- a/src/validateVc.test.ts
+++ b/src/validateVc.test.ts
@@ -3,8 +3,8 @@ import fetchMock from "jest-fetch-mock";
 import { validateVc } from "./validateVc";
 import { EXAMPLE_VCS, EXAMPLE_SCHEMAS } from "./examples";
 
-const vcString = EXAMPLE_VCS.DiplomaCredential;
-const vc = JSON.parse(EXAMPLE_VCS.DiplomaCredential);
+const vc = EXAMPLE_VCS.DiplomaCredential;
+const vcString = JSON.stringify(vc);
 
 beforeEach(() => {
   fetchMock.enableMocks();
@@ -42,7 +42,7 @@ it("should warn on missing `credentialSchema`", async () => {
 });
 it("should warn on unsupported `credentialSchema.type`", async () => {
   const { valid, warnings, errors } = await validateVc({
-    ...vc,
+    ...(vc as any),
     credentialSchema: {
       ...vc.credentialSchema,
       type: "SomethingElse",
@@ -55,7 +55,7 @@ it("should warn on unsupported `credentialSchema.type`", async () => {
 });
 it("should fail on missing `credentialSchema.id`", async () => {
   const { valid, warnings, errors } = await validateVc({
-    ...vc,
+    ...(vc as any),
     credentialSchema: {
       ...vc.credentialSchema,
       id: undefined,
@@ -87,7 +87,7 @@ it("should warn on non-200 response when fetching JSON Schema", async () => {
 
 it("should detect missing property from base VC schema even if no JSON Schema provided", async () => {
   const { valid, warnings, errors } = await validateVc({
-    ...vc,
+    ...(vc as any),
     credentialSchema: undefined,
     "@context": undefined,
   });

--- a/src/validateVc.ts
+++ b/src/validateVc.ts
@@ -1,8 +1,8 @@
-import Ajv from "ajv";
+import { ValidateFunction } from "ajv";
 import "cross-fetch/polyfill";
 import { Response } from "cross-fetch";
 import { VC } from "./types";
-import { baseVcJsonSchema } from "./helpers";
+import { baseVcJsonSchema, getNewAjv } from "./helpers";
 
 export async function validateVc(
   _vc: string | VC,
@@ -64,9 +64,9 @@ export async function validateVc(
     }
   }
 
-  let validator: Ajv.ValidateFunction | undefined;
+  let validator: ValidateFunction | undefined;
   try {
-    const ajv = new Ajv();
+    const ajv = getNewAjv();
     validator = ajv.compile(jsonSchema || baseVcJsonSchema);
   } catch (err) {
     errors.push(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,6 +1732,15 @@
     prop-types "^15.6.2"
     recompose "^0.27.1"
 
+"@digitalbazaar/http-client@^1.1.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@digitalbazaar/http-client/-/http-client-1.2.0.tgz#1ea3661e77000a15bd892a294f20dc6cc5d1c93b"
+  integrity sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==
+  dependencies:
+    esm "^3.2.22"
+    ky "^0.25.1"
+    ky-universal "^0.8.2"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -2889,6 +2898,15 @@
     "@svgr/plugin-svgo" "^5.4.0"
     loader-utils "^2.0.0"
 
+"@transmute/jsonld-schema@^0.7.0-unstable.24":
+  version "0.7.0-unstable.24"
+  resolved "https://registry.yarnpkg.com/@transmute/jsonld-schema/-/jsonld-schema-0.7.0-unstable.24.tgz#dfb8a13cf6ae8e6f24157ef171a829a7af4f371b"
+  integrity sha512-OypuFOLhyNG0kBkMM6xBa0jH92eAnXFr1oOc87clx5OM8HCuAdkyxqYG2oAdBoz50pHY6a9KcD35f2IQYcAI0g==
+  dependencies:
+    ajv "^8.6.1"
+    genson-js "0.0.5"
+    jsonld "^5.2.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -3473,6 +3491,13 @@ abab@^2.0.3:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -3558,6 +3583,13 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -3577,6 +3609,16 @@ ajv@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.0.4.tgz#827e5f5ae32f5e5c1637db61f253a112229b5e2f"
   integrity sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.6.1, ajv@^8.7.1:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.7.1.tgz#52be6f1736b076074798124293618f132ad07a7e"
+  integrity sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -4875,6 +4917,11 @@ caniuse-lite@^1.0.30001208:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001210.tgz#7c12d029e93b725cc2fe44a5eaabd9b838250d33"
   integrity sha512-avmGf0Jo00I8vB0I89J4Pba48kddasErV7slu7wrkyM5uY9gE5P+B+V3hjABv8Hp4YNG2nBqIUFUXlnqNteXEA==
 
+canonicalize@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.5.tgz#b43b390ce981d397908bb847c3a8d9614323a47b"
+  integrity sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA==
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -5871,6 +5918,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
+  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -5949,14 +6001,6 @@ deepdash-es@^5.3.5:
   integrity sha512-bezxT+LqAu1Ly8I2LAEFle3fdEAc/bHld9cMAbgYzY+69+P9qTkGtNvC2ZQJEP4C1C2Fx9gVn/TCoQlAivWPDA==
   dependencies:
     lodash-es "^4.17.15"
-
-deepdash@^5.3.9:
-  version "5.3.9"
-  resolved "https://registry.yarnpkg.com/deepdash/-/deepdash-5.3.9.tgz#2aa92570d7b1787ed281e2fafe0be24df00ddfe4"
-  integrity sha512-GRzJ0q9PDj2T+J2fX+b+TlUa2NlZ11l6vJ8LHNKVGeZ8CfxCuJaCychTq07iDRTvlfO8435jlvVS1QXBrW9kMg==
-  dependencies:
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -6778,6 +6822,11 @@ eslint@^7.11.0, eslint@^7.18.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+esm@^3.2.22:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -6840,6 +6889,11 @@ ethereum-blockies@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ethereum-blockies/-/ethereum-blockies-0.1.1.tgz#879fe959deef492a7a92b43dc34ae8dc2ee591fc"
   integrity sha1-h5/pWd7vSSp6krQ9w0ro3C7lkfw=
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^4.0.0:
   version "4.0.7"
@@ -7121,6 +7175,11 @@ fbjs@^0.8.1:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
+
+fetch-blob@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-2.1.2.tgz#a7805db1361bd44c1ef62bb57fb5fe8ea173ef3c"
+  integrity sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -7508,6 +7567,11 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+genson-js@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/genson-js/-/genson-js-0.0.5.tgz#706e2c940d0a9e6790777fb1fe5eb8f82c3d6fa7"
+  integrity sha512-1i1y9MIGzTRkn4TusWQwLWLu8IJGHgSE+fbQRt1fy68ZKEq2GjDZI/7NUSZFOfTbHz8bgjP4iCIOcdYrgEsMBA==
 
 gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -9434,6 +9498,16 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonld@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-5.2.0.tgz#d1e8af38a334cb95edf0f2ae4e2b58baf8d2b5a9"
+  integrity sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==
+  dependencies:
+    "@digitalbazaar/http-client" "^1.1.0"
+    canonicalize "^1.0.1"
+    lru-cache "^6.0.0"
+    rdf-canonize "^3.0.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -9504,6 +9578,19 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+ky-universal@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/ky-universal/-/ky-universal-0.8.2.tgz#edc398d54cf495d7d6830aa1ab69559a3cc7f824"
+  integrity sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==
+  dependencies:
+    abort-controller "^3.0.0"
+    node-fetch "3.0.0-beta.9"
+
+ky@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-0.25.1.tgz#0df0bd872a9cc57e31acd5dbc1443547c881bfbc"
+  integrity sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -9642,11 +9729,6 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
   integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -9692,7 +9774,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.x, lodash@^4.17.21:
+lodash@4.x:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10212,6 +10294,14 @@ node-fetch@2.6.1, node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@3.0.0-beta.9:
+  version "3.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.0.0-beta.9.tgz#0a7554cfb824380dd6812864389923c783c80d9b"
+  integrity sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==
+  dependencies:
+    data-uri-to-buffer "^3.0.1"
+    fetch-blob "^2.1.1"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -11966,6 +12056,13 @@ raw-loader@^4.0.1:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+rdf-canonize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-3.0.0.tgz#f5bade563e5e58f5cc5881afcba3c43839e8c747"
+  integrity sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==
+  dependencies:
+    setimmediate "^1.0.5"
 
 react-app-polyfill@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Previously we used a made-up superset of JSON-LD that compiled to regular JSON-LD context and JSON Schema. Now using a less-made-up JSON Schema that can compile to JSON-LD, developed by Transmute and W3C working group, as described here https://github.com/w3c-ccg/traceability-vocab#ontology-structure and here https://github.com/transmute-industries/verifiable-data/tree/main/packages/jsonld-schema.

This is being done because:

- it is a cleaner and better approach
- it is used by other groups and will be more interoperable
- it makes it much easier and more native to implement schema references

